### PR TITLE
Fixes history-based redirect on register page;Added additional dialog prompts.

### DIFF
--- a/src/components/auth/Register.js
+++ b/src/components/auth/Register.js
@@ -1,5 +1,5 @@
 import React, { useRef } from "react"
-import { Link } from "react-router-dom"
+import { Link, useHistory } from "react-router-dom"
 import "./Auth.css"
 
 export const Register = (props) => {
@@ -10,6 +10,8 @@ export const Register = (props) => {
     const password = useRef()
     const verifyPassword = useRef()
     const passwordDialog = useRef()
+    const userExistsDialog = useRef()
+    const history = useHistory()
 
     const handleRegister = (e) => {
         e.preventDefault()
@@ -36,7 +38,9 @@ export const Register = (props) => {
                 .then(res => {
                     if ("valid" in res && res.valid) {
                         localStorage.setItem("rare_user_id", res.token)
-                        props.history.push("/")
+                        history.push("/")
+                    } else {
+                        userExistsDialog.current.showModal()
                     }
                 })
         } else {
@@ -50,6 +54,11 @@ export const Register = (props) => {
             <dialog className="dialog dialog--password" ref={passwordDialog}>
                 <div>Passwords do not match</div>
                 <button className="button--close" onClick={e => passwordDialog.current.close()}>Close</button>
+            </dialog>
+
+            <dialog className="dialog dialog--password" ref={userExistsDialog}>
+                <div>User already registered</div>
+                <button className="button--close" onClick={e => userExistsDialog.current.close()}>Close</button>
             </dialog>
 
             <form className="form--login" onSubmit={handleRegister}>


### PR DESCRIPTION
The redirect from the Register component wasn't working as it was attempting to use props.  Updated to utilize `useHistory` instead, which is what the Login component was using.

Added an additional prompt for when a user is already registered with an email address, when attempting to register that email address.
