### PR TITLE
Sorted tags regardless of capitalization

### DIFF
--- a/src/components/tags/Tags.js
+++ b/src/components/tags/Tags.js
@@ -9,7 +9,7 @@ const AllTags = () => {
         fetch("http://localhost:8088/tags")
             .then(res => res.json())
             // Sort the results by the 'name' field
-            .then(res => res.sort((a,b) => (a.name > b.name) ? 1 : -1))
+            .then(res => res.sort((a, b) => ((a.name).toLowerCase() > (b.name).toLowerCase()) ? 1 : -1))
             .then(setAllTags, [])
     }, [])
 


### PR DESCRIPTION
This sorts the tags by their lowercase values (i.e. regardless of case in the tag name).

Previously, tag values were sorted first by those that started with a capital letter, then those that started with a lower-case letter.