### PR TITLE
Fixed redirect after creating new category

### DIFF
--- a/src/components/categories/NewCategory.js
+++ b/src/components/categories/NewCategory.js
@@ -38,7 +38,7 @@ class NewCategory extends React.Component {
     })
       .then(res => res.json())
       .then(res => {
-        this.props.history.push('/category')
+        this.props.history.push('/categories')
       })
   }
 


### PR DESCRIPTION
1) Fixed redirect after creating a new category.  It was redirecting to `/category` but should have been redirecting to `/categories`.